### PR TITLE
Mapping Error with elasticsearch 8.10.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:8.10.0"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:8.11.1"
     ports:
       - 9200:9200
     restart: on-failure


### PR DESCRIPTION
I noticed when using the provided docker-compose.yml that indexing (and querying) dense vectors fails with the following error:

`raise HTTP_EXCEPTIONS.get(meta.status, ApiError)(
elasticsearch.BadRequestError: BadRequestError(400, 'mapper_parsing_exception', 'Missing required parameter [dims] for field [embedding]')`

Changing to elasticsearch 8.11.1 as described in the docs [here](https://docs.haystack.deepset.ai/docs/elasticsearch-document-store#initialization) has resolved the issue for me.